### PR TITLE
126 directional relationship names

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddRelationshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRelationshipCommand.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FORWARD_RELATIONSHIP_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REVERSE_RELATIONSHIP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_USERID;
 
@@ -25,13 +26,15 @@ public class AddRelationshipCommand extends Command {
             + "Parameters: "
             + PREFIX_USERID + "USER_ID_1 "
             + PREFIX_USERID + "USER_ID_2 "
-            + PREFIX_NAME + "RELATIONSHIP_NAME "
+            + PREFIX_FORWARD_RELATIONSHIP_NAME + "FORWARD_RELATIONSHIP_NAME "
+            + PREFIX_REVERSE_RELATIONSHIP_NAME + "REVERSE_RELATIONSHIP_NAME "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_USERID + "12345678 "
             + PREFIX_USERID + "87654321 "
-            + PREFIX_NAME + "Business Partner "
-            + PREFIX_TAG + "Investment" + "\n"
+            + PREFIX_FORWARD_RELATIONSHIP_NAME + "Boss of "
+            + PREFIX_REVERSE_RELATIONSHIP_NAME + "Reports to "
+            + PREFIX_TAG + "Work" + "\n"
             + "Note: You can find a person's ID displayed in the contact card.";
 
     public static final String MESSAGE_SUCCESS = "Relationship successfully added.";
@@ -42,21 +45,25 @@ public class AddRelationshipCommand extends Command {
 
     private final String userId1;
     private final String userId2;
-    private final String relationshipName;
+    private final String forwardName;
+    private final String reverseName;
     private final Set<Tag> tags;
 
     /**
      * Creates an AddRelationshipCommand to add the specified relationship.
      */
-    public AddRelationshipCommand(String userId1, String userId2, String relationshipName, Set<Tag> tags) {
+    public AddRelationshipCommand(String userId1, String userId2, String forwardName, String reverseName,
+                                  Set<Tag> tags) {
         requireNonNull(userId1);
         requireNonNull(userId2);
-        requireNonNull(relationshipName);
+        requireNonNull(forwardName);
+        requireNonNull(reverseName);
         requireNonNull(tags);
 
         this.userId1 = userId1;
         this.userId2 = userId2;
-        this.relationshipName = relationshipName;
+        this.forwardName = forwardName;
+        this.reverseName = reverseName;
         this.tags = tags;
     }
 
@@ -68,7 +75,7 @@ public class AddRelationshipCommand extends Command {
             throw new CommandException(MESSAGE_SAME_PERSON);
         }
 
-        if (relationshipName.trim().isEmpty()) {
+        if (forwardName.trim().isEmpty() || reverseName.trim().isEmpty()) {
             throw new CommandException(MESSAGE_EMPTY_NAME);
         }
 
@@ -81,11 +88,12 @@ public class AddRelationshipCommand extends Command {
         }
 
         // Check if the same relationship already exists
-        if (model.hasRelationship(userId1, userId2, relationshipName)) {
+        if (model.hasRelationship(userId1, userId2, forwardName)
+                || model.hasRelationship(userId2, userId1, reverseName)) {
             throw new CommandException(MESSAGE_DUPLICATE_RELATIONSHIP);
         }
 
-        Relationship relationship = new Relationship(userId1, userId2, relationshipName, tags);
+        Relationship relationship = new Relationship(userId1, userId2, forwardName, reverseName, tags);
         model.addRelationship(relationship);
         return new CommandResult(MESSAGE_SUCCESS);
     }
@@ -103,7 +111,8 @@ public class AddRelationshipCommand extends Command {
 
         return userId1.equals(otherCommand.userId1)
                 && userId2.equals(otherCommand.userId2)
-                && relationshipName.equals(otherCommand.relationshipName)
+                && forwardName.equals(otherCommand.forwardName)
+                && reverseName.equals(otherCommand.reverseName)
                 && tags.equals(otherCommand.tags);
     }
 
@@ -112,7 +121,8 @@ public class AddRelationshipCommand extends Command {
         return new ToStringBuilder(this)
                 .add("userId1", userId1)
                 .add("userId2", userId2)
-                .add("relationshipName", relationshipName)
+                .add("forwardName", forwardName)
+                .add("reverseName", reverseName)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteRelationshipCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteRelationshipCommand.java
@@ -26,7 +26,8 @@ public class DeleteRelationshipCommand extends Command {
             + PREFIX_USERID + "12345678 "
             + PREFIX_USERID + "87654321 "
             + PREFIX_NAME + "Business Partner" + "\n"
-            + "Note: You can find a person's ID displayed in the contact card.";
+            + "Note: You can use either the forward or reverse relationship name to identify the relationship.\n"
+            + "You can find a person's ID displayed in the contact card.";
 
     public static final String MESSAGE_SUCCESS = "Relationship successfully deleted.";
     public static final String MESSAGE_RELATIONSHIP_NOT_FOUND = "Error: Relationship not found.";

--- a/src/main/java/seedu/address/logic/parser/AddRelationshipCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddRelationshipCommandParser.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FORWARD_RELATIONSHIP_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REVERSE_RELATIONSHIP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_USERID;
 
@@ -17,7 +18,6 @@ import seedu.address.model.tag.Tag;
  * Parses input arguments and creates a new AddRelationshipCommand object
  */
 public class AddRelationshipCommandParser implements Parser<AddRelationshipCommand> {
-
     /**
      * Parses the given {@code String} of arguments in the context of the AddRelationshipCommand
      * and returns an AddRelationshipCommand object for execution.
@@ -25,10 +25,12 @@ public class AddRelationshipCommandParser implements Parser<AddRelationshipComma
      */
     public AddRelationshipCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_USERID, PREFIX_NAME, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_USERID, PREFIX_FORWARD_RELATIONSHIP_NAME,
+                        PREFIX_REVERSE_RELATIONSHIP_NAME, PREFIX_TAG);
 
-        // Check if we have both user IDs
-        if (!arePrefixesPresent(argMultimap, PREFIX_USERID, PREFIX_NAME)
+        // Check if we have both user IDs and both relationship names
+        if (!arePrefixesPresent(argMultimap, PREFIX_USERID, PREFIX_FORWARD_RELATIONSHIP_NAME,
+                PREFIX_REVERSE_RELATIONSHIP_NAME)
                 || argMultimap.getAllValues(PREFIX_USERID).size() != 2
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -40,18 +42,18 @@ public class AddRelationshipCommandParser implements Parser<AddRelationshipComma
         String userId1 = userIds.get(0);
         String userId2 = userIds.get(1);
 
-        // Get the relationship name
-        String relationshipName = argMultimap.getValue(PREFIX_NAME).get();
+        // Get the relationship names
+        String forwardName = argMultimap.getValue(PREFIX_FORWARD_RELATIONSHIP_NAME).get();
+        String reverseName = argMultimap.getValue(PREFIX_REVERSE_RELATIONSHIP_NAME).get();
 
         // Get the tags, if any
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        return new AddRelationshipCommand(userId1, userId2, relationshipName, tagList);
+        return new AddRelationshipCommand(userId1, userId2, forwardName, reverseName, tagList);
     }
 
     /**
-     * Returns true if the prefix is present and has a non-empty value in the given
-     * ArgumentMultimap.
+     * Returns true if all required prefixes are present and have non-empty values.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -21,4 +21,6 @@ public class CliSyntax {
 
     // Relationship prefixes.
     public static final Prefix PREFIX_USERID = new Prefix("u/");
+    public static final Prefix PREFIX_FORWARD_RELATIONSHIP_NAME = new Prefix("fn/");
+    public static final Prefix PREFIX_REVERSE_RELATIONSHIP_NAME = new Prefix("rn/");
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -129,6 +129,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if there is any relationship between the two users.
+     */
+    public boolean hasAnyRelationship(String userId1, String userId2) {
+        requireAllNonNull(userId1, userId2);
+        return relationships.containsAnyRelationship(userId1, userId2);
+    }
+
+    /**
      * Adds a relationship to the address book.
      * The relationship must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -98,14 +98,22 @@ public interface Model {
     Person getPersonById(String id);
 
     /**
-     * Returns true if a relationship with the same identity fields as {@code relationship} exists in the address book.
+     * Returns true if a relationship with the same identity fields exists in the address book.
      */
     boolean hasRelationship(Relationship relationship);
 
     /**
-     * Returns true if a relationship with the given user IDs and name exists in the address book.
+     * Returns true if a relationship exists between the given users.
+     * The relationship can be found using either the forward or reverse name.
+     * The order of user IDs doesn't matter.
      */
     boolean hasRelationship(String userId1, String userId2, String relationshipName);
+
+    /**
+     * Returns true if any relationship exists between the given users,
+     * regardless of the relationship names.
+     */
+    boolean hasAnyRelationship(String userId1, String userId2);
 
     /**
      * Adds a relationship to the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -155,6 +155,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasAnyRelationship(String userId1, String userId2) {
+        requireAllNonNull(userId1, userId2);
+        return addressBook.hasAnyRelationship(userId1, userId2);
+    }
+
+    @Override
     public void addRelationship(Relationship relationship) {
         addressBook.addRelationship(relationship);
         updateFilteredRelationshipList(PREDICATE_SHOW_ALL_RELATIONSHIPS);

--- a/src/main/java/seedu/address/model/relationship/UniqueRelationshipList.java
+++ b/src/main/java/seedu/address/model/relationship/UniqueRelationshipList.java
@@ -49,6 +49,18 @@ public class UniqueRelationshipList implements Iterable<Relationship> {
     }
 
     /**
+     * Checks if the list contains any relationship between the given users, regardless of the relationship names.
+     * @param userId1 The user ID of the first user.
+     * @param userId2 The user ID of the second user.
+     * @return True if the list contains any relationship between the given users, False otherwise.
+     */
+    public boolean containsAnyRelationship(String userId1, String userId2) {
+        return internalList.stream()
+                .anyMatch(r -> (r.getUser1Id().equals(userId1) && r.getUser2Id().equals(userId2))
+                        || (r.getUser1Id().equals(userId2) && r.getUser2Id().equals(userId1)));
+    }
+
+    /**
      * Adds a relationship to the list.
      * The relationship must not already exist in the list.
      *

--- a/src/main/java/seedu/address/storage/JsonAdaptedRelationship.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRelationship.java
@@ -21,7 +21,8 @@ class JsonAdaptedRelationship {
 
     private final String user1Id;
     private final String user2Id;
-    private final String name;
+    private final String forwardName;
+    private final String reverseName;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -31,11 +32,13 @@ class JsonAdaptedRelationship {
     public JsonAdaptedRelationship(
             @JsonProperty("user1Id") String user1Id,
             @JsonProperty("user2Id") String user2Id,
-            @JsonProperty("name") String name,
+            @JsonProperty("forwardName") String forwardName,
+            @JsonProperty("reverseName") String reverseName,
             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.user1Id = user1Id;
         this.user2Id = user2Id;
-        this.name = name;
+        this.forwardName = forwardName;
+        this.reverseName = reverseName;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -47,7 +50,8 @@ class JsonAdaptedRelationship {
     public JsonAdaptedRelationship(Relationship source) {
         user1Id = source.getUser1Id();
         user2Id = source.getUser2Id();
-        name = source.getName();
+        forwardName = source.getForwardName();
+        reverseName = source.getReverseName();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .toList());
@@ -72,15 +76,19 @@ class JsonAdaptedRelationship {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "User 2 ID"));
         }
 
-        if (name == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Name"));
+        if (forwardName == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Forward Name"));
         }
 
-        if (!Relationship.isValidRelationshipName(name)) {
+        if (reverseName == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Reverse Name"));
+        }
+
+        if (!Relationship.isValidRelationshipName(forwardName) || !Relationship.isValidRelationshipName(reverseName)) {
             throw new IllegalValueException(Relationship.MESSAGE_CONSTRAINTS);
         }
 
         final Set<Tag> modelTags = new HashSet<>(relationshipTags);
-        return new Relationship(user1Id, user2Id, name, modelTags);
+        return new Relationship(user1Id, user2Id, forwardName, reverseName, modelTags);
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -92,22 +92,19 @@ public class PersonCard extends UiPart<Region> {
             HBox relationshipBox = new HBox();
             relationshipBox.setSpacing(5);
 
-            Label relationshipLabel = new Label(relationship.getName());
+            // Get the relationship name from this person's perspective
+            String relationshipName = relationship.getNameFromPerspective(person.getId());
+            Label relationshipLabel = new Label(relationshipName);
             relationshipLabel.getStyleClass().add("relationship-name");
 
-            Label withLabel = new Label("with");
-            withLabel.getStyleClass().add("relationship-with");
-
-            // Determine the other person in the relationship
+            // Get the other person's details
             String otherId = person.getId().equals(relationship.getUser1Id())
                     ? relationship.getUser2Id() : relationship.getUser1Id();
-
-            // Fetch the other person and display their name
             String otherPersonName = getOtherPersonName(otherId);
-            Label otherPersonLabel = new Label(otherPersonName + " (" + otherId + ")");
+            Label otherPersonLabel = new Label(otherPersonName);
             otherPersonLabel.getStyleClass().add("relationship-person");
 
-            relationshipBox.getChildren().addAll(relationshipLabel, withLabel, otherPersonLabel);
+            relationshipBox.getChildren().addAll(relationshipLabel, otherPersonLabel);
             relationshipsPane.getChildren().add(relationshipBox);
 
             // Add tags for this relationship if any

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -89,7 +89,7 @@ public class AddCommandTest {
     /**
      * A default model stub that have all of the methods failing.
      */
-    private class ModelStub implements Model {
+    private static class ModelStub implements Model {
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");
@@ -172,6 +172,11 @@ public class AddCommandTest {
 
         @Override
         public boolean hasRelationship(String userId1, String userId2, String relationshipName) {
+            return false;
+        }
+
+        @Override
+        public boolean hasAnyRelationship(String userId1, String userId2) {
             return false;
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddRelationshipCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRelationshipCommandTest.java
@@ -24,21 +24,31 @@ public class AddRelationshipCommandTest {
                 null,
                 "2",
                 "Friend",
+                "Reports to",
                 new HashSet<>()));
         assertThrows(NullPointerException.class, () -> new AddRelationshipCommand(
                 "1",
                 null,
                 "Friend",
+                "Reports to",
                 new HashSet<>()));
         assertThrows(NullPointerException.class, () -> new AddRelationshipCommand(
                 "1",
                 "2",
+                null,
+                "Reports to",
+                new HashSet<>()));
+        assertThrows(NullPointerException.class, () -> new AddRelationshipCommand(
+                "1",
+                "2",
+                "Friend",
                 null,
                 new HashSet<>()));
         assertThrows(NullPointerException.class, () -> new AddRelationshipCommand(
                 "1",
                 "2",
                 "Friend",
+                "Reports to",
                 null));
     }
 
@@ -56,7 +66,7 @@ public class AddRelationshipCommandTest {
                 .build();
 
         CommandResult commandResult = new AddRelationshipCommand(
-                person1.getId(), person2.getId(), "Friend", new HashSet<>()).execute(modelStub);
+                person1.getId(), person2.getId(), "Boss of", "Reports to", new HashSet<>()).execute(modelStub);
 
         assertEquals(AddRelationshipCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
         assertEquals(validRelationship, modelStub.relationshipAdded);
@@ -70,7 +80,7 @@ public class AddRelationshipCommandTest {
         ModelStub modelStub = new ModelStubWithPersonsAndRelationship(person1, person2);
 
         AddRelationshipCommand addRelationshipCommand = new AddRelationshipCommand(
-                person1.getId(), person2.getId(), "Friend", new HashSet<>());
+                person1.getId(), person2.getId(), "Boss of", "Reports to", new HashSet<>());
 
         assertThrows(CommandException.class,
                 AddRelationshipCommand.MESSAGE_DUPLICATE_RELATIONSHIP, () -> addRelationshipCommand.execute(modelStub));
@@ -83,7 +93,7 @@ public class AddRelationshipCommandTest {
         ModelStub modelStub = new ModelStubWithPerson(person);
 
         AddRelationshipCommand addRelationshipCommand = new AddRelationshipCommand(
-                person.getId(), person.getId(), "Friend", new HashSet<>());
+                person.getId(), person.getId(), "Boss of", "Reports to", new HashSet<>());
 
         assertThrows(CommandException.class,
                 AddRelationshipCommand.MESSAGE_SAME_PERSON, () -> addRelationshipCommand.execute(modelStub));
@@ -97,7 +107,7 @@ public class AddRelationshipCommandTest {
         ModelStub modelStub = new ModelStubWithPersons(person1, person2);
 
         AddRelationshipCommand addRelationshipCommand = new AddRelationshipCommand(
-                person1.getId(), person2.getId(), "", new HashSet<>());
+                person1.getId(), person2.getId(), "", "", new HashSet<>());
 
         assertThrows(CommandException.class,
                 AddRelationshipCommand.MESSAGE_EMPTY_NAME, () -> addRelationshipCommand.execute(modelStub));
@@ -111,16 +121,16 @@ public class AddRelationshipCommandTest {
         String name2 = "BusinessPartner";
 
         AddRelationshipCommand addFriendCommand = new AddRelationshipCommand(
-                user1Id, user2Id, name1, new HashSet<>());
+                user1Id, user2Id, name1, "Reports to", new HashSet<>());
         AddRelationshipCommand addBusinessPartnerCommand = new AddRelationshipCommand(
-                user1Id, user2Id, name2, new HashSet<>());
+                user1Id, user2Id, name2, "Reports to", new HashSet<>());
 
         // same object -> returns true
         assertEquals(addFriendCommand, addFriendCommand);
 
         // same values -> returns true
         AddRelationshipCommand addFriendCommandCopy = new AddRelationshipCommand(
-                user1Id, user2Id, name1, new HashSet<>());
+                user1Id, user2Id, name1, "Reports to", new HashSet<>());
         assertEquals(addFriendCommand, addFriendCommandCopy);
 
         // different types -> returns false
@@ -181,7 +191,7 @@ public class AddRelationshipCommandTest {
     /**
      * A Model stub that contains two persons and a relationship between them.
      */
-    private class ModelStubWithPersonsAndRelationship extends ModelStubWithPersons {
+    private static class ModelStubWithPersonsAndRelationship extends ModelStubWithPersons {
         private final Relationship relationship;
 
         ModelStubWithPersonsAndRelationship(Person person1, Person person2) {

--- a/src/test/java/seedu/address/logic/commands/DeleteRelationshipCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteRelationshipCommandTest.java
@@ -40,7 +40,7 @@ public class DeleteRelationshipCommandTest {
         modelStub.addRelationship(relationship);
 
         CommandResult commandResult = new DeleteRelationshipCommand(
-                person1.getId(), person2.getId(), "Friend").execute(modelStub);
+                person1.getId(), person2.getId(), RelationshipBuilder.DEFAULT_FORWARD_NAME).execute(modelStub);
 
         assertEquals(DeleteRelationshipCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
         assertTrue(modelStub.relationshipDeleted);

--- a/src/test/java/seedu/address/logic/parser/AddRelationshipCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddRelationshipCommandParserTest.java
@@ -19,21 +19,21 @@ public class AddRelationshipCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         // Basic case
-        assertParseSuccess(parser, " u/1 u/2 n/Friend",
-                new AddRelationshipCommand("1", "2", "Friend", new HashSet<>()));
+        assertParseSuccess(parser, " u/1 u/2 fn/Friend rn/Reports to",
+                new AddRelationshipCommand("1", "2", "Friend", "Reports to", new HashSet<>()));
 
         // With tags
         Set<Tag> tags = new HashSet<>();
         tags.add(new Tag(VALID_TAG_FRIEND));
-        assertParseSuccess(parser, " u/1 u/2 n/Friend t/friend",
-                new AddRelationshipCommand("1", "2", "Friend", tags));
+        assertParseSuccess(parser, " u/1 u/2 fn/Friend rn/Reports to t/friend",
+                new AddRelationshipCommand("1", "2", "Friend", "Reports to", tags));
 
         // With multiple tags
         Set<Tag> multipleTags = new HashSet<>();
         multipleTags.add(new Tag(VALID_TAG_FRIEND));
         multipleTags.add(new Tag("colleague"));
-        assertParseSuccess(parser, " u/1 u/2 n/Friend t/friend t/colleague",
-                new AddRelationshipCommand("1", "2", "Friend", multipleTags));
+        assertParseSuccess(parser, " u/1 u/2 fn/Friend rn/Reports to t/friend t/colleague",
+                new AddRelationshipCommand("1", "2", "Friend", "Reports to", multipleTags));
     }
 
     @Test
@@ -41,10 +41,10 @@ public class AddRelationshipCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRelationshipCommand.MESSAGE_USAGE);
 
         // Missing user ID prefixes
-        assertParseFailure(parser, " n/Friend", expectedMessage);
+        assertParseFailure(parser, " fn/Friend rn/Reports to", expectedMessage);
 
         // Only one user ID
-        assertParseFailure(parser, " u/1 n/Friend", expectedMessage);
+        assertParseFailure(parser, " u/1 fn/Friend rn/Reports to", expectedMessage);
 
         // Missing name prefix
         assertParseFailure(parser, " u/1 u/2", expectedMessage);
@@ -56,11 +56,11 @@ public class AddRelationshipCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // Non-empty preamble
-        assertParseFailure(parser, "some random string u/1 u/2 n/Friend",
+        assertParseFailure(parser, "some random string u/1 u/2 fn/Friend rn/Reports to",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRelationshipCommand.MESSAGE_USAGE));
 
         // Invalid tag
-        assertParseFailure(parser, " u/1 u/2 n/Friend t/*&",
+        assertParseFailure(parser, " u/1 u/2 fn/Friend rn/Reports to t/*&",
                 Tag.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -150,7 +150,7 @@ public class AddressBookTest {
                 .withUser2Id(bob.getId())
                 .build();
         addressBook.addRelationship(relationship);
-        assertTrue(addressBook.hasRelationship(alice.getId(), bob.getId(), "Friend"));
+        assertTrue(addressBook.hasRelationship(alice.getId(), bob.getId(), RelationshipBuilder.DEFAULT_FORWARD_NAME));
     }
 
     @Test
@@ -166,13 +166,13 @@ public class AddressBookTest {
                 .build();
         addressBook.addRelationship(relationship);
 
-        addressBook.removeRelationship(alice.getId(), bob.getId(), "Friend");
+        addressBook.removeRelationship(alice.getId(), bob.getId(), RelationshipBuilder.DEFAULT_FORWARD_NAME);
         assertFalse(addressBook.hasRelationship(relationship));
     }
 
     @Test
     public void removeRelationship_nonExistingRelationship_throwsRelationshipNotFoundException() {
-        assertThrows(RelationshipNotFoundException.class, () -> addressBook.removeRelationship("1", "2", "Friend"));
+        assertThrows(RelationshipNotFoundException.class, () -> addressBook.removeRelationship("1", "2", RelationshipBuilder.DEFAULT_FORWARD_NAME));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -172,7 +172,8 @@ public class AddressBookTest {
 
     @Test
     public void removeRelationship_nonExistingRelationship_throwsRelationshipNotFoundException() {
-        assertThrows(RelationshipNotFoundException.class, () -> addressBook.removeRelationship("1", "2", RelationshipBuilder.DEFAULT_FORWARD_NAME));
+        assertThrows(RelationshipNotFoundException.class, () -> addressBook.removeRelationship("1", "2",
+                RelationshipBuilder.DEFAULT_FORWARD_NAME));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -160,7 +160,7 @@ public class ModelManagerTest {
 
     @Test
     public void updateRelationship_nullParameters_throwsNullPointerException() {
-        Relationship relationship = new Relationship("1", "2", "Friend", new HashSet<>());
+        Relationship relationship = new Relationship("1", "2", "Friend", "Reports to", new HashSet<>());
         assertThrows(NullPointerException.class, () -> modelManager.updateRelationship(null, relationship));
         assertThrows(NullPointerException.class, () -> modelManager.updateRelationship(relationship, null));
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedRelationshipTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedRelationshipTest.java
@@ -19,7 +19,8 @@ public class JsonAdaptedRelationshipTest {
 
     private static final String VALID_USER1_ID = "123456";
     private static final String VALID_USER2_ID = "654321";
-    private static final String VALID_NAME = "Friend";
+    private static final String VALID_FORWARD_NAME = "Boss of";
+    private static final String VALID_REVERSE_NAME = "Reports to";
     private static final List<JsonAdaptedTag> VALID_TAGS = new RelationshipBuilder().build().getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -34,23 +35,35 @@ public class JsonAdaptedRelationshipTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedRelationship relationship =
-                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, INVALID_NAME, VALID_TAGS);
+                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, INVALID_NAME, VALID_REVERSE_NAME,
+                        VALID_TAGS);
         String expectedMessage = Relationship.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, relationship::toModelType);
+
+        JsonAdaptedRelationship relationshipReverse =
+                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, VALID_FORWARD_NAME, INVALID_NAME,
+                        VALID_TAGS);
+        assertThrows(IllegalValueException.class, expectedMessage, relationshipReverse::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedRelationship relationship =
-                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, null, VALID_TAGS);
-        String expectedMessage = String.format(JsonAdaptedRelationship.MISSING_FIELD_MESSAGE_FORMAT, "Name");
+                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, null, VALID_REVERSE_NAME, VALID_TAGS);
+        String expectedMessage = String.format(JsonAdaptedRelationship.MISSING_FIELD_MESSAGE_FORMAT, "Forward Name");
         assertThrows(IllegalValueException.class, expectedMessage, relationship::toModelType);
+
+        JsonAdaptedRelationship relationshipReverse =
+                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, VALID_FORWARD_NAME, null, VALID_TAGS);
+        String expectedMessageReverse = String.format(JsonAdaptedRelationship.MISSING_FIELD_MESSAGE_FORMAT,
+                "Reverse Name");
+        assertThrows(IllegalValueException.class, expectedMessageReverse, relationshipReverse::toModelType);
     }
 
     @Test
     public void toModelType_nullUser1Id_throwsIllegalValueException() {
         JsonAdaptedRelationship relationship =
-                new JsonAdaptedRelationship(null, VALID_USER2_ID, VALID_NAME, VALID_TAGS);
+                new JsonAdaptedRelationship(null, VALID_USER2_ID, VALID_FORWARD_NAME, VALID_REVERSE_NAME, VALID_TAGS);
         String expectedMessage = String.format(JsonAdaptedRelationship.MISSING_FIELD_MESSAGE_FORMAT, "User 1 ID");
         assertThrows(IllegalValueException.class, expectedMessage, relationship::toModelType);
     }
@@ -58,7 +71,7 @@ public class JsonAdaptedRelationshipTest {
     @Test
     public void toModelType_nullUser2Id_throwsIllegalValueException() {
         JsonAdaptedRelationship relationship =
-                new JsonAdaptedRelationship(VALID_USER1_ID, null, VALID_NAME, VALID_TAGS);
+                new JsonAdaptedRelationship(VALID_USER1_ID, null, VALID_FORWARD_NAME, VALID_REVERSE_NAME, VALID_TAGS);
         String expectedMessage = String.format(JsonAdaptedRelationship.MISSING_FIELD_MESSAGE_FORMAT, "User 2 ID");
         assertThrows(IllegalValueException.class, expectedMessage, relationship::toModelType);
     }
@@ -68,7 +81,8 @@ public class JsonAdaptedRelationshipTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedRelationship relationship =
-                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, VALID_NAME, invalidTags);
+                new JsonAdaptedRelationship(VALID_USER1_ID, VALID_USER2_ID, VALID_FORWARD_NAME, VALID_REVERSE_NAME,
+                        invalidTags);
         assertThrows(IllegalValueException.class, relationship::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -110,6 +110,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean hasAnyRelationship(String userId1, String userId2) {
+        return false;
+    }
+
+    @Override
     public void addRelationship(Relationship relationship) {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/testutil/RelationshipBuilder.java
+++ b/src/test/java/seedu/address/testutil/RelationshipBuilder.java
@@ -14,11 +14,13 @@ public class RelationshipBuilder {
 
     public static final String DEFAULT_USER1_ID = "123456";
     public static final String DEFAULT_USER2_ID = "654321";
-    public static final String DEFAULT_NAME = "Friend";
+    public static final String DEFAULT_FORWARD_NAME = "Boss of";
+    public static final String DEFAULT_REVERSE_NAME = "Reports to";
 
     private String user1Id;
     private String user2Id;
-    private String name;
+    private String forwardName;
+    private String reverseName;
     private Set<Tag> tags;
 
     /**
@@ -27,7 +29,8 @@ public class RelationshipBuilder {
     public RelationshipBuilder() {
         user1Id = DEFAULT_USER1_ID;
         user2Id = DEFAULT_USER2_ID;
-        name = DEFAULT_NAME;
+        forwardName = DEFAULT_FORWARD_NAME;
+        reverseName = DEFAULT_REVERSE_NAME;
         tags = new HashSet<>();
     }
 
@@ -37,8 +40,29 @@ public class RelationshipBuilder {
     public RelationshipBuilder(Relationship relationshipToCopy) {
         user1Id = relationshipToCopy.getUser1Id();
         user2Id = relationshipToCopy.getUser2Id();
-        name = relationshipToCopy.getName();
+        forwardName = relationshipToCopy.getForwardName();
+        reverseName = relationshipToCopy.getReverseName();
         tags = new HashSet<>(relationshipToCopy.getTags());
+    }
+
+    /**
+     * Sets the {@code forwardName} of the {@code Relationship} that we are building.
+     * @param name The name of the relationship from user1 to user2.
+     * @return The RelationshipBuilder with the forwardName set.
+     */
+    public RelationshipBuilder withForwardName(String name) {
+        this.forwardName = name;
+        return this;
+    }
+
+    /**
+     * Sets the {@code reverseName} of the {@code Relationship} that we are building.
+     * @param name The name of the relationship from user2 to user1.
+     * @return The RelationshipBuilder with the reverseName set.
+     */
+    public RelationshipBuilder withReverseName(String name) {
+        this.reverseName = name;
+        return this;
     }
 
     /**
@@ -58,14 +82,6 @@ public class RelationshipBuilder {
     }
 
     /**
-     * Sets the {@code name} of the {@code Relationship} that we are building.
-     */
-    public RelationshipBuilder withName(String name) {
-        this.name = name;
-        return this;
-    }
-
-    /**
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Relationship} that we are building.
      */
     public RelationshipBuilder withTags(String ... tags) {
@@ -74,6 +90,6 @@ public class RelationshipBuilder {
     }
 
     public Relationship build() {
-        return new Relationship(user1Id, user2Id, name, tags);
+        return new Relationship(user1Id, user2Id, forwardName, reverseName, tags);
     }
 }


### PR DESCRIPTION
Relationship names can now be asymmetric. Users must specify a forward name as well as a reverse name. The developer and user guides still need to be updated accordingly.

Fixes #126.